### PR TITLE
add additional check for transactions

### DIFF
--- a/src/pages/Transactions/index.tsx
+++ b/src/pages/Transactions/index.tsx
@@ -34,9 +34,11 @@ const Transactions = () => {
         if (lastJsonMessage && lastJsonMessage.op === 'utx') {
             const transaction = lastJsonMessage.x;
 
-            dispatch(addTransaction(transaction));
+            if (isSubscribed) {
+                dispatch(addTransaction(transaction));
+            }
         }
-    }, [lastJsonMessage, dispatch]);
+    }, [isSubscribed, lastJsonMessage, dispatch]);
 
     useEffect(() => {
         return () => {


### PR DESCRIPTION
Bug: when moving between pages on transactions page lastJsonMessage added to transactions.
Fix: Added additional check for transactions, so lastJsonMessage will adding if isSubscribed = true